### PR TITLE
FTB Genesis: Updated default world label to match recommended

### DIFF
--- a/ftbgenesis_server.xml
+++ b/ftbgenesis_server.xml
@@ -74,7 +74,7 @@
       Type="Variable"
       Name="LEVEL"
       Target="LEVEL"
-      Default="world"
+      Default="FTBGenesis"
       Description="Name of the world directory.  It is usually world."
       Display="advanced"
       Required="false"


### PR DESCRIPTION
Per the [docs for this pack](https://feed-the-beast.com/modpacks/120-ftb-genesis?tab=about), the default world_name should be `FTBGenesis` not the normal `world`